### PR TITLE
Migration to Version 2.0.0

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "github.vscode-github-actions",
-        "bierner.github-markdown-preview"
+        "bierner.github-markdown-preview",
+        "exodiusstudios.comment-anchors"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "github.vscode-github-actions",
+        "bierner.github-markdown-preview"
+    ]
+}

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -1,1 +1,1 @@
-["index"]
+["index", "migration_v2"]

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -17,16 +17,118 @@ export default defineConfig({
 * With this plugin you can add multiple public folders
 
 ## Install
-``npm i -D vite-multiple-assets``
 
-## Config options
+```sh
+npm i -D vite-multiple-assets
+```
 
-- dirAssets: list of your static directories
-- mimeTypes: Add your extended content types, by default there will be the following content types
-- ssr: default is `false` support client side, using with Solid-js or framework support SSR please enable this flag to `true`
+## Basic Usage
+
+In `vite.config.ts`
+```ts
+import { type PluginOption } from 'vite'
+import DynamicPublicDirectory from "vite-multiple-assets";
+// same level as project root
+const dirAssets = ["public/**", "libs/assets/**", "repo1/assets/**"];
+
+// example
+const mimeTypes = {
+    '.acc':'application/acc'
+}
+
+export default defineConfig({
+    plugins: [
+        DynamicPublicDirectory( dirAssets, {
+            ssr: true,
+            mimeTypes
+        }) as PluginOption
+    ],
+    publicDir: false,
+})
+```
+* With the above configuration will automatically add files in `libs/assets`, `repo1/assets` folders as static assets for your project
+* It also recommended to set `publicDir` to `false` to avoid confusion
+* Notic the wildcard `**`, this plugin use glob pattern by default. You could also review [fast-glob](https://www.npmjs.com/package/fast-glob) and [micromatch](https://www.npmjs.com/package/micromatch/v/3.1.10)
+
+### Example
+[Detail](https://github.com/nguyenbatranvan/vite-multiple-assets/blob/main/packages/examples/react/vite.config.ts)
+
+## Options
 
 ```ts
+import type { PluginOption } from "vite";
+
+export default function DynamicPublicDirectory(assets: IAssets, opts: IConfig = {}): PluginOption
+```
+
+```ts
+import type { Options } from "fast-glob";
+
+export interface IConfigExtend extends Partial<Pick<Options, "ignore" | "dot">> {
+    dst?: string | FDst;
+}
+
+export type IMIME = Record<string, string>;
+
+export interface IConfig extends 
+    IConfigExtend, 
+    Partial<Pick<Options, "onlyFiles" | "onlyDirectories" | "cwd" | "markDirectories">> 
 {
+    mimeTypes?: IMIME;
+    ssr?: boolean;
+}
+```
+
+### `assets`
+
+```ts
+var assets: IAssets = [];
+type IAssets = string[];
+```
+
+List copied `assets` by following pattern defined in [`fast-glob` pattern](https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax) which is [Unix Glob](https://man7.org/linux/man-pages/man7/glob.7.html) [Pattern](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html). There are few things to take:
+
+- always use forward-slash `/` for path, and use backslash to escape character
+- do not use single-dot `./**/*.txt` `./abc/**/*.txt` for current path, instead straight use the pattern `**/*.txt` `abc/**/*.txt`
+- If you are hope certain folder included to be copied, make it in selectable list pattern, `dir1/{\x01,folder_name}/**`. Just ensure there is no folder or file named by first ascii
+
+For example:
+
+```ts
+export default defineConfig({
+    plugins: [
+        DynamicPublicDirectory( [
+            "public/{\x01, models}/**", // order is important
+            "public/**", // basic public needs
+            "../../assets/**" // you could go to upper level
+        ] )
+    ],
+    publicDir: false,
+})
+```
+
+### `opts.cwd`
+
+### `opts.ssr`
+
+```ts
+var opts_ssr: boolean | undefined = false;
+```
+
+SSR option accept certain value:
+- `true`: support using Solid-js or framework with SSR
+- `false` (default): support client side, static build
+
+If you need to go up, you could use `%2E%2E/file.txt` as alternative of `../file.txt`. Also, you could you `%2Fetc/wwwroot` as alternative of `/etc/wwwroot`. Just in case you need it.
+
+### `opts.mimeTypes`
+
+```ts
+
+var opts_mimeTypes: IMIME = {}
+export type IMIME = Record<string, string>;
+
+const internalMimeTypes: IMIME = {
     ".html": "text/html",
     ".js": "text/javascript",
     ".css": "text/css",
@@ -55,39 +157,18 @@ export default defineConfig({
     ".zip": "application/zip",
     ".rar": "application/x-rar-compressed",
     ".7z": "application/x-7z-compressed"
-}
+};
+
 ```
 
-**Note:** In case the content type is not found, it will be automatically handled according to the ```mime-types``` library
+You could define your extended content types using `opts.mimeTypes`. This feature could be use when using `SSR` mode. There are few hierarchi when choosing the right types:
 
+1. get the last extention and compare it to your `opt.mimeTypes`. If not exists,
+2. get the last extention and compare it to `internalMimeTypes`. If not exists,
+3. do `mime.lookup` to the entire filename so it will be automatically handled according to the [```mime-types```](https://www.npmjs.com/package/mime-types) library by [`mime-db`](https://www.npmjs.com/package/mime-db). If not exists,
+4. just use `.html` content type from `opts.mimeTypes` and then `internalMimeTypes`. If not exists,
+5. just lookup `.html` content type from `mime-types`
 
-In `vite.config.ts`
-```ts
-import DynamicPublicDirectory from "vite-multiple-assets";
-// same level as project root
-const dirAssets=["libs/assets","repo1/assets",...];
+### `opts.dst`
 
-// example
-const mimeTypes = {
-    '.acc':'application/acc'
-}
-
-export default defineConfig({
-    plugins: [
-        DynamicPublicDirectory(dirAssets,{
-            ssr:true,
-            mimeTypes
-        })
-    ]
-})
-```
-* With the above configuration will automatically add files in `public`, `libs/assets`, `repo1/assets` folders as static assets for your project, which can be understood as below:
-
- ```ts
- export default defineConfig({
-    // default is public folder
-    publicDir:["public","libs/assets","repo1/assets",...]
-  })
-```
-### Example
-[Detail](https://github.com/nguyenbatranvan/vite-multiple-assets/blob/main/packages/examples/react/vite.config.ts)
+### `opts.ignore`

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -27,7 +27,7 @@ npm i -D vite-multiple-assets
 In `vite.config.ts`
 ```ts
 import { type PluginOption } from 'vite'
-import DynamicPublicDirectory from "vite-multiple-assets";
+import { DynamicPublicDirectory } from "vite-multiple-assets";
 // same level as project root
 const dirAssets = ["public/**", "libs/{\x01,assets}/**", "repo1/{\x01,assets}/**"];
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -50,6 +50,22 @@ export default defineConfig({
 * It also recommended to set `publicDir` to `false` to avoid confusion
 * Notice the wildcard `**`, this plugin use glob pattern by default. You could also review [fast-glob](https://www.npmjs.com/package/fast-glob) and [micromatch](https://www.npmjs.com/package/micromatch)
 
+### Astro Support
+
+In `astro.config.mjs`
+```ts
+import {defineConfig} from 'astro/config';
+import {astroMultipleAssets} from "vite-multiple-assets";
+
+const assets = ['public2/**'];
+// https://astro.build/config
+export default defineConfig({
+    integrations: [
+        astroMultipleAssets(assets)
+    ],
+});
+```
+
 ### Example
 [Detail](https://github.com/nguyenbatranvan/vite-multiple-assets/blob/main/packages/examples/react/vite.config.ts)
 
@@ -240,7 +256,7 @@ export type IFilesMapper = Partial<Record<string, string>>; // STUB: { baseTrans
 Where the files would be copied. In default, it would reuse Rollup output or Vite output. This options allow user to reroutes to different folder, or prorammatically reroutes these copied files and rename it. Programmatically reroutes has 3 return options:
 - `string`: path with filename relative to default destination directory, or absolute path. Rules from `assets` also applied.
 - `false`: do not copy file. Can be use to programmatically ignore certain file. Use this if you need complex use-case.
-- `void`: copy to default name and destination
+- `undefined`: copy to default name and destination
 
 You could reroutes to different folder:
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -48,7 +48,7 @@ export default defineConfig({
 ```
 * With the above configuration will automatically add files in `libs/assets`, `repo1/assets` folders as static assets for your project
 * It also recommended to set `publicDir` to `false` to avoid confusion
-* Notic the wildcard `**`, this plugin use glob pattern by default. You could also review [fast-glob](https://www.npmjs.com/package/fast-glob) and [micromatch](https://www.npmjs.com/package/micromatch/v/3.1.10)
+* Notice the wildcard `**`, this plugin use glob pattern by default. You could also review [fast-glob](https://www.npmjs.com/package/fast-glob) and [micromatch](https://www.npmjs.com/package/micromatch)
 
 ### Example
 [Detail](https://github.com/nguyenbatranvan/vite-multiple-assets/blob/main/packages/examples/react/vite.config.ts)
@@ -127,7 +127,7 @@ Where does the beginning root to traverse all directory and files. If you not de
 ### `opts.ssr`
 
 ```ts
-var opts_ssr: boolean | undefined = false;
+var opts_ssr: boolean = false;
 ```
 
 SSR option accept certain value:

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -339,4 +339,4 @@ All `opts.*` internally directly passed to `fast-glob`, so you could override `o
 const opts_absolute: boolean = false;
 ```
 
-This option is forced to be `false`. All path would return to relative path from `cwd` such as `C:/Users/user/` or `/home/user/` (notice they are forward-slash). These is intended due to simpler internal logic, and to ensure this plugin would copy the right file and folder with no ambiguity.
+This option is forced to be `false`. All path would return to relative path from `cwd`. These is intended due to simpler internal logic, and easier in rejoin path to `dst`.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -68,8 +68,6 @@ export interface IConfigExtend extends Partial<Pick<Options, "ignore" | "dot">> 
     dst?: string | FDst;
 }
 
-export type IMIME = Record<string, string>;
-
 export interface IConfig extends 
     IConfigExtend, 
     Partial<Pick<Options, "onlyFiles" | "onlyDirectories" | "cwd" | "markDirectories">> 
@@ -78,6 +76,9 @@ export interface IConfig extends
     ssr?: boolean;
 }
 ```
+
+<!-- NOTE: for documenters, these options is ordered from the most important to the less -->
+<!-- NOTE: types sample using `var` instead of `let` and `const` as function arguments are `var` by design -->
 
 ### `assets`
 
@@ -108,6 +109,12 @@ export default defineConfig({
 ```
 
 ### `opts.cwd`
+
+```ts
+var opts_cwd: string = process.cwd();
+```
+
+Where does the beginning root to traverse all directory and files. If you not define, it would goes using Vite's `.root`. If not defined, it would goes using `process.cwd()` by default.
 
 ### `opts.ssr`
 
@@ -169,6 +176,85 @@ You could define your extended content types using `opts.mimeTypes`. This featur
 4. just use `.html` content type from `opts.mimeTypes` and then `internalMimeTypes`. If not exists,
 5. just lookup `.html` content type from `mime-types`
 
+### `opts.ignore`
+
+```ts
+var opts_ignore: string[] = [];
+```
+
+List of pattern to be ignored. If you want to include all files from root and inside `public/` but not the public itself, you could do as follow:
+
+```ts
+export default defineConfig({
+    plugins: [
+        DynamicPublicDirectory( [ "public/**", "**" ], {
+            ignore: ["/public"]
+        } )
+    ],
+    publicDir: false,
+})
+```
+
+**Notice:** `public/**` and `/public` are different.
+
 ### `opts.dst`
 
-### `opts.ignore`
+### `opts.dot`
+
+```ts
+var opts_dot: boolean = true;
+```
+
+Also search for dotfile (hidden files of linux). Those are in examples `.env`, `.npmrc`, `.git/`, `.gitignore/`, etc. For conveince to make everything discoverable, this option is `true` by default.
+
+### `opts.onlyFiles`
+
+```ts
+var opts_onlyFiles: boolean = true;
+```
+
+Search and gather only files (with no directories). For convenience to get lower size and more countable, this option is `true` by default. If you want to also copy empty folder, you could set `false` to this options. It would be wise if you also set `opts.onlyDirectories` to `false`.
+
+### `opts.onlyDirectories`
+
+```ts
+var opts_onlyDirectories: boolean = false;
+```
+
+Search and gather only directories (with no files). Opposite to `opts.onlyFies`, this option is `false` by default. Assuming, just copying folders is useless.
+
+> Enable this options can lead to duplication issue, the folder which contains files inside it also reached, and also all folders inside it. When coping the folder, the same folders may be copied twice or more. 
+
+### `opts.markDirectories`
+
+```ts
+var opts_markDirectories: boolean = true;
+```
+
+Mark all path of directory noticeable by adding the last slash at the end of the path. For conveince, this option is `true` by default. Assume this structure:
+
+```css
+dirA/
+\_ dirAA/
+\_ file.txt
+dirB/
+```
+
+The list of folder could be:
+
+```css
+dirA/
+dirA/dirAA/
+dirA/file.txt
+dirB/
+```
+
+## Enforced Behaviors
+
+All `opts.*` internally directly passed to `fast-glob`, so you could override `opts` types and use any `fast-glob` available flags. This is not recommended as these options already selected to fit internal logic and this plugin original use-case and ideation. Even though that, there is options that is enforced to satisfy internal logic.
+
+## `opts.absolute`
+
+```ts
+const opts_absolute: boolean = true;
+```

--- a/docs/guide/migration_v2.md
+++ b/docs/guide/migration_v2.md
@@ -5,6 +5,8 @@
 Basically, this major would allow you to do this:
 
 ```ts
+import { DynamicPublicDirectory } from "vite-multiple-assets";
+
 const defaultExcluded = ["{,**/}.git/**", "{,**/}{,*}.local{,/**}", "src/**", "dist/**", "node_modules/**", "public/**", "vite.config.*.*"];
 
 DynamicPublicDirectory(["public/**", "**"], {
@@ -27,7 +29,8 @@ This major is taking advantage of Globs Pattern using [fast-glob](https://www.np
 
 ```diff
 + import { type PluginOption } from 'vite'
-import DynamicPublicDirectory from "vite-multiple-assets";
+- import DynamicPublicDirectory from "vite-multiple-assets";
++ import { DynamicPublicDirectory } from "vite-multiple-assets";
 // same level as project root
 - const dirAssets=["libs/assets","repo1/assets", "/"];
 + const dirAssets=["libs/{\x01,assets}/**","repo1/{\x01,assets}/**", "**"];

--- a/docs/guide/migration_v2.md
+++ b/docs/guide/migration_v2.md
@@ -12,7 +12,7 @@ DynamicPublicDirectory(["public/**", "**"], {
 }) as PluginOption,
 ```
 
-**What does it do?** \
+**What does it do?**
 - It would copy everything from public to `dist/`
 - It would also copy everything from the root to `dist/`
 - But, except junks and cache like `.git`, `*.local`, and `node_modules`
@@ -30,7 +30,7 @@ This major is taking advantage of Globs Pattern using [fast-glob](https://www.np
 import DynamicPublicDirectory from "vite-multiple-assets";
 // same level as project root
 - const dirAssets=["libs/assets","repo1/assets", "/"];
-+ const dirAssets=["libs/assets/**","repo1/assets/**", "**"];
++ const dirAssets=["libs/{\x01,assets}/**","repo1/{\x01,assets}/**", "**"];
 
 // example
 const mimeTypes = {

--- a/docs/guide/migration_v2.md
+++ b/docs/guide/migration_v2.md
@@ -1,0 +1,60 @@
+# Migration to V2
+
+## Quick Overview
+
+Basically, this major would allow you to do this:
+
+```ts
+const defaultExcluded = ["{,**/}.git/**", "{,**/}{,*}.local{,/**}", "src/**", "dist/**", "node_modules/**", "public/**", "vite.config.*.*"];
+
+DynamicPublicDirectory(["public/**", "**"], {
+    ignore: [...defaultExcluded.filter(v => v.search("public") == -1), "/public", "*lock*"],
+}) as PluginOption,
+```
+
+**What does it do?** \
+- It would copy everything from public to `dist/`
+- It would also copy everything from the root to `dist/`
+- But, except junks and cache like `.git`, `*.local`, and `node_modules`
+- It would also not copy `dist/` folder if it is already exists. (Well, we do not want deep duplication)
+- It would also exclude the `public/` itself, but not the content of it.
+
+That's it.
+
+## Migration Step
+
+This major is taking advantage of Globs Pattern using [fast-glob](https://www.npmjs.com/package/fast-glob) and [micromatch](https://www.npmjs.com/package/micromatch/v/3.1.10). Take a look at this basic v1 configuration:
+
+```diff
++ import { type PluginOption } from 'vite'
+import DynamicPublicDirectory from "vite-multiple-assets";
+// same level as project root
+- const dirAssets=["libs/assets","repo1/assets", "/"];
++ const dirAssets=["libs/assets/**","repo1/assets/**", "**"];
+
+// example
+const mimeTypes = {
+    '.acc':'application/acc'
+}
+
+export default defineConfig({
+    plugins: [
+        DynamicPublicDirectory(dirAssets,{
+            ssr:true,
+            mimeTypes
+-       })
++       }) as PluginOption
+    ]
+})
+```
+
+As such, you just need to add wildcard `/**` at the end of it
+
+See? There are no much to change.
+
+## Developer Notes
+
+- Please see [Featuring Glob, Excluding Files, and Change Output by FarhanMS123 · Pull Request #16](https://github.com/nguyenbatranvan/vite-multiple-assets/pull/16) and [Output asset folders at a subdirectory · Issue #9](https://github.com/nguyenbatranvan/vite-multiple-assets/issues/9) for more contexts
+- Add more options to use micromatch
+- Issue when path is beginning with `./` or has `/./`
+- Need update types to using vite instead of rollup


### PR DESCRIPTION
Hi,

As my promise (even though it already been months), I done this documentation for Vite Multiple Assets migration to Version 2,0.0. The original code can be look in this PR: https://github.com/nguyenbatranvan/vite-multiple-assets/pull/16 .

I also modify in how options documented, and giving examples and tricks in each options based on PR.

Thanks,